### PR TITLE
[i498] Fix the tabs on the Colours page

### DIFF
--- a/src/views/colour.vue
+++ b/src/views/colour.vue
@@ -15,7 +15,7 @@
     <p>
       <strong>Note for Devs:</strong> Using the generalized naming conventions for colours (<code>$primary-300</code>, <code>$bg-50</code>, <code>$tertiary-100</code>, etc) will automatically swap out colours based on the application build process. If your requirements state to use a specific colour regardless of theme the <code>$[name]-[weight]</code> convention will work (eg: <code>$jade-300</code>)
     </p>
-    <tabs :tabs="tabs" @change="setTab" >
+    <tabs :tabs="tabs" @change="setTab">
       <template #wealthbar>
         <wealthbar-theme />
       </template>


### PR DESCRIPTION
- The tabs on the colours page are currently broken. Clicking on `Assante` doesn't switch the tab to the Assante colors
- This PR just updates how the `<tabs>` component is implemented on the Colours page
- [Trello Issue](https://trello.com/c/oTmEG9XA/498-i498-broken-link-on-peak-colour-page)